### PR TITLE
changes for arm

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Deploy the guidance using:
 pnpm cdk deploy
 ```
 
+The deployment will automatically detect your system's architecture (AMD64 or ARM64) and use the appropriate architecture for Fargate containers.
+
 The cdk outputs cloudformation templates to the `cdk.out` folder. By running the following command you will be able to access these templates at `C2PaStack.template.json`
 
 The project will synthesize and then deploy

--- a/packages/infra/bin/infra.ts
+++ b/packages/infra/bin/infra.ts
@@ -7,6 +7,10 @@ import { AwsSolutionsChecks } from "cdk-nag";
 import "source-map-support/register";
 
 const app = new cdk.App();
+
+// Log the detected architecture
+console.log(`Detected architecture: ${process.arch}`);
+
 new C2paStack(app, "C2paStack", {
   env: {
     account: process.env.CDK_DEFAULT_ACCOUNT,

--- a/packages/infra/bin/infra.ts
+++ b/packages/infra/bin/infra.ts
@@ -8,9 +8,6 @@ import "source-map-support/register";
 
 const app = new cdk.App();
 
-// Log the detected architecture
-console.log(`Detected architecture: ${process.arch}`);
-
 new C2paStack(app, "C2paStack", {
   env: {
     account: process.env.CDK_DEFAULT_ACCOUNT,

--- a/packages/infra/bin/infra.ts
+++ b/packages/infra/bin/infra.ts
@@ -8,8 +8,6 @@ import "source-map-support/register";
 
 const app = new cdk.App();
 
-// Log the detected architecture
-console.log(`Detected architecture: ${process.arch}`);
 
 new C2paStack(app, "C2paStack", {
   env: {

--- a/packages/infra/lib/NestedStacks/C2pa/Fargate/Fargate.ts
+++ b/packages/infra/lib/NestedStacks/C2pa/Fargate/Fargate.ts
@@ -57,8 +57,16 @@ export class Fargate extends Construct {
         // https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-tasks-services.html#fargate-tasks-size
         cpu: 2048,
         memoryLimitMiB: 8192,
+        runtimePlatform: {
+          cpuArchitecture: process.arch === 'arm64' ? ecs.CpuArchitecture.ARM64 : ecs.CpuArchitecture.X86_64,
+          operatingSystemFamily: ecs.OperatingSystemFamily.LINUX,
+        },
         taskImageOptions: {
-          image: ecs.ContainerImage.fromAsset(path.join(__dirname, "code")),
+          image: ecs.ContainerImage.fromAsset(path.join(__dirname, "code"), {
+            buildArgs: {
+              ARCHITECTURE: process.arch === 'arm64' ? 'arm64' : 'amd64'
+            }
+          }),
           environment: {
             output_bucket: backendStorageBucket.bucketName,
             certificate: certificate.secretName,

--- a/packages/infra/lib/NestedStacks/C2pa/Fargate/code/Dockerfile
+++ b/packages/infra/lib/NestedStacks/C2pa/Fargate/code/Dockerfile
@@ -1,4 +1,5 @@
-FROM --platform=linux/amd64 rust
+ARG ARCHITECTURE=amd64
+FROM --platform=linux/${ARCHITECTURE} rust
 
 # Copy function code
 COPY . .

--- a/packages/webapp/src/common/C2paWebComponent.tsx
+++ b/packages/webapp/src/common/C2paWebComponent.tsx
@@ -60,12 +60,16 @@ export const C2paWebComponents = ({
       <img width={"100%"} src={imageUrl} />
       {manifestStore ? (
         <div>
+          {/* @ts-ignore */}
           <cai-popover
             style={{ position: "absolute", top: "10px", right: "10px" }}
             interactive
           >
+            {/* @ts-ignore */}
             <cai-indicator slot="trigger" />
+            {/* @ts-ignore */}
             <cai-manifest-summary ref={summaryRef} slot="content" />
+          {/* @ts-ignore */}
           </cai-popover>
         </div>
       ) : null}

--- a/packages/webapp/src/pages/Fmp4Manager/FMP4Library/FMP4Library.tsx
+++ b/packages/webapp/src/pages/Fmp4Manager/FMP4Library/FMP4Library.tsx
@@ -13,9 +13,8 @@ import { Link, useNavigate } from "react-router-dom";
 
 export const FMP4Library = () => {
   const navigate = useNavigate();
-
   const { data, isLoading, refetch, isRefetching } =
-    useListAssets("fragments/completed/");
+    useListAssets("fragments/assets/");
 
   return (
     <ContentLayout>

--- a/packages/webapp/tsconfig.app.json
+++ b/packages/webapp/tsconfig.app.json
@@ -20,5 +20,5 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src"]
+  "include": ["src", "src/types/*.d.ts"]
 }

--- a/packages/webapp/tsconfig.app.json
+++ b/packages/webapp/tsconfig.app.json
@@ -20,5 +20,5 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src", "src/types/*.d.ts"]
+  "include": ["src"]
 }


### PR DESCRIPTION
Changes to accept ARM or x86-64.

ts-ignores are because of errors in following while building: weabpp 
src/common/C2paWebComponent.tsx(63,11): error TS2339: Property 'cai-popover' does not exist on type 'JSX.IntrinsicElements'.
src/common/C2paWebComponent.tsx(67,13): error TS2339: Property 'cai-indicator' does not exist on type 'JSX.IntrinsicElements'.
src/common/C2paWebComponent.tsx(68,13): error TS2339: Property 'cai-manifest-summary' does not exist on type 'JSX.IntrinsicElements'.
src/common/C2paWebComponent.tsx(69,11): error TS2339: Property 'cai-popover' does not exist on type 'JSX.IntrinsicElements'.
·ELIFECYCLE· Command failed with exit code 2.
[Container] 2025/07/22 00:58:51.661462 Command failed with exit status 2
[Container] 2025/07/22 00:58:51.718969 Running command (cd dist && zip -r ../dist.zip .)
/tmp/codebuild/output/tmp/script.sh: line 4: cd: dist: No such file or directory

[Container] 2025/07/22 00:58:51.724089 Command failed with exit status 1